### PR TITLE
Fix NOMINMAX redefinition warnings on MinGW

### DIFF
--- a/include/EAMain/EAEntryPointMain.inl
+++ b/include/EAMain/EAEntryPointMain.inl
@@ -17,7 +17,9 @@
     EA_DISABLE_ALL_VC_WARNINGS()
     #include <EAStdC/EAString.h>
     #include <malloc.h>
-    #define NOMINMAX
+    #ifndef NOMINMAX
+        #define NOMINMAX
+    #endif
     #include <Windows.h>
     #undef NOMINMAX
     EA_RESTORE_ALL_VC_WARNINGS()


### PR DESCRIPTION
MinGW-w64 already defines NOMINMAX in one of its base headers, so this fires a warning during building of EASTL tests.