### PR TITLE
Fix build on Ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ add_definitions(-DEAMAIN_NETWORK_CHANNEL_PORT=8080)
 #-------------------------------------------------------------------------------------------
 target_include_directories(EAMain PUBLIC include)
 target_include_directories(EAMain PUBLIC source)
+target_include_directories(EAMain PRIVATE ../EABase/include/Common)
 
 #-------------------------------------------------------------------------------------------
 # Package Dependencies 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,6 @@ target_include_directories(EAMain PRIVATE ../EABase/include/Common)
 #-------------------------------------------------------------------------------------------
 # Package Dependencies 
 #-------------------------------------------------------------------------------------------
-target_link_libraries(EAMain EABase)
 target_link_libraries(EAMain EAAssert)
 target_link_libraries(EAMain EAStdC)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,7 +43,7 @@ add_subdirectory(packages/EAStdC)
 add_subdirectory(packages/EATest)
 add_subdirectory(packages/EAThread)
 
-target_link_libraries(EAMainTest EABase)
+)
 target_link_libraries(EAMainTest EAAssert)
 target_link_libraries(EAMainTest EAMain)
 target_link_libraries(EAMainTest EASTL)


### PR DESCRIPTION
Change EABase from link to include - the libraries won't build otherwise on Ubuntu.
I'm guessing that in the past EABase *was* a binary library to link against, and was changed to header only - but I didn't chase its history.